### PR TITLE
Typo in Readme parameters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -149,7 +149,7 @@ Configuration (TypeScript type).
     — style of quotes to use
 *   `smart` (`Array<string>`, default: `['“”', '‘’']`)
     — list of quotes to see as “smart”
-*   `smart` (`Array<string>`, default: `['"', "'"]`)
+*   `straight` (`Array<string>`, default: `['"', "'"]`)
     — list of quotes to see as “straight”
 
 ## Messages


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aretextjs&type=issues and https://github.com/orgs/retextjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Fixes a small documentation typo in the readme: `smart` parameter exists 2x, alto I think the second one meants to say `straight`

<!--do not edit: pr-->
