### PR TITLE
[fix] Logic error with quotes order

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,7 +116,7 @@ export default function retextQuotes(options) {
           expected = preferred === 'smart' ? '’' : "'"
         } else {
           const markers = preferred === 'smart' ? smart : straight
-          expected = markers[(stack.length + 1) % markers.length]
+          expected = markers[(stack.length - 1) % markers.length]
 
           if (expected.length > 1) {
             expected = expected.charAt(style.type === 'open' ? 0 : 1)

--- a/test.js
+++ b/test.js
@@ -23,6 +23,12 @@ const nesting = [
   '\'One "sentence". Two sentences.\''
 ].join('\n\n')
 
+const multiNesting = [
+  'A sentence “with ‘multi «mutli “nested ‘quotes’”»’”.', // correct case when {smart: ['“”', '‘’', '«»']} (TODO: REMOVE THESE COMMENTS!!!)
+  'A sentence ‘with “multi «mutli ‘nested “quotes”’»”’.', // '“”' and '‘’' are swapped -> wrong
+  'A sentence «with “multi ‘mutli «nested “quotes”»’”».' // that's how it is currently evalutes to be right -> but it should be wrong
+].join('\n\n')
+
 const moreApostrophes = 'Isn’t it funny? It was acceptable in the ’80s'
 
 const soManyOpenings = '“Open this, ‘Open that, “open here, ‘open there'
@@ -191,6 +197,39 @@ test('retextQuotes', async function (t) {
         '7:6-7:7: Unexpected `"` at this level of nesting, expected `\'`',
         '7:15-7:16: Unexpected `"` at this level of nesting, expected `\'`',
         '7:32-7:33: Unexpected `\'` at this level of nesting, expected `"`'
+      ])
+    }
+  )
+
+  await t.test(
+    'should detect nesting with more than 2 defined quotes correctly',
+    async function () {
+      const file = await retext()
+        .use(retextQuotes, {smart: ['“”', '‘’', '«»']})
+        .process(multiNesting)
+
+      console.log(file.messages.map(String))
+
+      assert.deepEqual(file.messages.map(String), [
+        '3:12-3:13: Unexpected `‘` at this level of nesting, expected `“`',
+        '3:18-3:19: Unexpected `“` at this level of nesting, expected `‘`',
+        '3:32-3:33: Unexpected `‘` at this level of nesting, expected `“`',
+        '3:40-3:41: Unexpected `“` at this level of nesting, expected `‘`',
+        '3:47-3:48: Unexpected `”` at this level of nesting, expected `’`',
+        '3:48-3:49: Unexpected `’` at this level of nesting, expected `”`',
+        '3:50-3:51: Unexpected `”` at this level of nesting, expected `’`',
+        '3:51-3:52: Unexpected `’` at this level of nesting, expected `”`',
+
+        '5:12-5:13: Unexpected `«` at this level of nesting, expected `“`',
+        '5:18-5:19: Unexpected `“` at this level of nesting, expected `‘`',
+        '5:25-5:26: Unexpected `‘` at this level of nesting, expected `«`',
+        '5:32-5:33: Unexpected `«` at this level of nesting, expected `“`',
+        '5:40-5:41: Unexpected `“` at this level of nesting, expected `‘`',
+        '5:47-5:48: Unexpected `”` at this level of nesting, expected `’`',
+        '5:48-5:49: Unexpected `»` at this level of nesting, expected `”`',
+        '5:49-5:50: Unexpected `’` at this level of nesting, expected `»`',
+        '5:50-5:51: Unexpected `”` at this level of nesting, expected `’`',
+        '5:51-5:52: Unexpected `»` at this level of nesting, expected `”`'
       ])
     }
   )


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aretextjs&type=issues and https://github.com/orgs/retextjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

In [this line](https://github.com/retextjs/retext-quotes/blob/main/lib%2Findex.js#L119) there is a small logic error, which went unnoticed because there are currently no tests for setting either `smart` or `straight`. 

**Detailed context:**

Let's say these are the current vars:

```js
markers = ['“”', '‘’', '«»']
stack = [{ "“", "smart", "open" }]
```

And now look at this line:

```js
expected = markers[(stack.length + 1) % markers.length]
```

We take the length of the stack, which is 1, add 1 to it, which makes 2 and module (`%`) it with the length of the markers, which is 3, in order to make sure, that we don't get any out of range exception.

We expect that the `expected` variable is set to the first item in markers, namely `'“”'` because this is the very first quote in the paragraph, as you can see: The stack only has the one item, no other quotes have been opened.

However, the item with index 2 is the third item, which leads the plugin to say, that the first quote is wrong, it should be the third quote...

Basically, we are ALWAYS 2 indecies ahead of the actual marker we want to be in the var `expected`.

This went unnoticed until now, because all tests only ever have max 2 entries in the markers array, which by coincidence doesn't affect the output, because the module `%` resets it to 0, so `expected` gets set to the right item / right index.

In order to fix this behaviour, **we have to subtract 1 from the stack length**, so we are exactly at the index we want to be, like this:

```js
expected = markers[(stack.length - 1) % markers.length]
```

If you have any further questions explaining the issue, please let me know!

- Fix #11 
